### PR TITLE
BML near-neighbor additions to chromosome database

### DIFF
--- a/src/chromosomes.tsv
+++ b/src/chromosomes.tsv
@@ -199,20 +199,19 @@ Mycobacterium_leprae	AL450380	1769	1763	NCBI-REF
 Mycobacterium_tuberculosis	AL123456	1773	77643	NCBI-REF
 Mycolicibacterium_fortuitum	AP025518	144549	1766	NCBI-REF
 Mycoplasma_mycoides	BX293980	2102	656088	NCBI-REF
-Neisseria_bergeri	No_complete_genomes
 Neisseria_cinerea	CP065726	483 482 FDA-ARGOS
-Neisseria_elongata	CP031255	495 482 CDC SME* 
+Neisseria_elongata	CP031255	495 482 CDC SME
 Neisseria_flavescens	CP039886	484 482 NCBI-REF
 Neisseria_gonorrhoeae	AE004969	485	482	CDC SME
-Neisseria_lactamica	CP031253	486 482 CDC SME*
+Neisseria_lactamica	CP031253	486 482 CDC SME
 Neisseria_meningitidis	AE002098	487	482	CDC SME
-Neisseria_polysaccharea	CP031325	489 482 CDC SME*	
+Neisseria_polysaccharea	CP031325	489 482 CDC SME
 Neisseria_sicca	CP059566	490 482 NCBI-REF	
-Neisseria_subflava	CP039887	28449	482 NCBI-REF**
+Neisseria_subflava	CP039887	28449	482 NCBI-REF
 Neisseria_weaveri	LR134533	28091	482 NCBI-REF
 Neomysis_japonica	KR006340	1676841	223649	UGA SME
 Nocardia_asteroides	CP089227	1824	1817	FDA-ARGOS
-Nocardia_farcinica	CP031418	37329	1817	NCBI-REF(CDC)
+Nocardia_farcinica	CP031418	37329	1817	NCBI-REF
 Ochrobactrum_anthropi	CP000758	529	528	NCBI-REF
 Ochrobactrum_anthropi	CP000759	529	528	NCBI-REF
 Pantoea_ananatis	CP001875	553	53335	NCBI-REF


### PR DESCRIPTION
Added reference genomes for 29 species. See bb3270cdb60a3118f8e39846e5f0279d93b6f1a6 and 0862cbcff423c4b69bbb6adc1c6b172b0feb2b3e for detailed information on species added and selection information. There is one less genome in the PR than bb3270cdb60a3118f8e39846e5f0279d93b6f1a6 due to N. bergeri having no complete genomes available. This genome will go into a separate incomplete chromosomes database. 

Note that some diffs will be due to having sorted the list, which corrected some alphabetical ordering.